### PR TITLE
feat: Add pod entities support (#59)

### DIFF
--- a/custom_components/kubernetes/const.py
+++ b/custom_components/kubernetes/const.py
@@ -32,6 +32,7 @@ CONF_SCALE_COOLDOWN = "scale_cooldown"
 
 # Sensor types
 SENSOR_TYPE_PODS = "pods"
+SENSOR_TYPE_POD = "pod"
 SENSOR_TYPE_NODES = "nodes"
 SENSOR_TYPE_DEPLOYMENTS = "deployments"
 SENSOR_TYPE_STATEFULSETS = "statefulsets"

--- a/custom_components/kubernetes/kubernetes_client.py
+++ b/custom_components/kubernetes/kubernetes_client.py
@@ -323,6 +323,156 @@ class KubernetesClient:
             self._log_error("aiohttp get all pods count", ex)
             return 0
 
+    async def get_pods(self) -> list[dict[str, Any]]:
+        """Get detailed information about all pods in the namespace(s)."""
+        try:
+            # Test connection first
+            if not await self._test_connection():
+                _LOGGER.error("Cannot connect to Kubernetes API")
+                return []
+
+            # Use aiohttp as primary since it works better with SSL configuration
+            if self.monitor_all_namespaces:
+                result = await self._get_pods_all_namespaces_aiohttp()
+            else:
+                result = await self._get_pods_aiohttp()
+
+            if result is not None:
+                self._log_success("get pods", f"retrieved {len(result)} pods")
+            return result
+
+        except Exception as ex:
+            self._log_error("get pods", ex)
+            return []
+
+    async def _get_pods_aiohttp(self) -> list[dict[str, Any]]:
+        """Get pods using aiohttp for single namespace."""
+        try:
+            headers = {
+                "Authorization": f"Bearer {self.api_token}",
+                "Accept": "application/json",
+            }
+
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"https://{self.host}:{self.port}/api/v1/namespaces/{self.namespace}/pods",
+                    headers=headers,
+                    ssl=self.verify_ssl,
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as response:
+                    if response.status == 200:
+                        data = await response.json()
+                        return self._parse_pods_data(data.get("items", []))
+                    else:
+                        _LOGGER.error(
+                            "aiohttp pods request failed with status: %s",
+                            response.status,
+                        )
+                        return []
+        except Exception as ex:
+            self._log_error("aiohttp get pods", ex)
+            return []
+
+    async def _get_pods_all_namespaces_aiohttp(self) -> list[dict[str, Any]]:
+        """Get pods using aiohttp for all namespaces."""
+        try:
+            headers = {
+                "Authorization": f"Bearer {self.api_token}",
+                "Accept": "application/json",
+            }
+
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"https://{self.host}:{self.port}/api/v1/pods",
+                    headers=headers,
+                    ssl=self.verify_ssl,
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as response:
+                    if response.status == 200:
+                        data = await response.json()
+                        return self._parse_pods_data(data.get("items", []))
+                    else:
+                        _LOGGER.error(
+                            "aiohttp all pods request failed with status: %s",
+                            response.status,
+                        )
+                        return []
+        except Exception as ex:
+            self._log_error("aiohttp get all pods", ex)
+            return []
+
+    def _parse_pods_data(self, pods: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Parse raw pod data from Kubernetes API into standardized format."""
+        parsed_pods = []
+
+        for pod in pods:
+            try:
+                metadata = pod.get("metadata", {})
+                spec = pod.get("spec", {})
+                status = pod.get("status", {})
+
+                # Get pod phase
+                phase = status.get("phase", "Unknown")
+
+                # Get container statuses
+                container_statuses = status.get("containerStatuses", [])
+                ready_containers = 0
+                total_containers = len(container_statuses)
+
+                for container_status in container_statuses:
+                    if container_status.get("ready", False):
+                        ready_containers += 1
+
+                # Get restart count
+                restart_count = 0
+                for container_status in container_statuses:
+                    restart_count += container_status.get("restartCount", 0)
+
+                # Get node name
+                node_name = spec.get("nodeName", "N/A")
+
+                # Get pod IP
+                pod_ip = status.get("podIP", "N/A")
+
+                # Get creation timestamp
+                creation_timestamp = metadata.get("creationTimestamp", "N/A")
+
+                # Get labels
+                labels = metadata.get("labels", {})
+
+                # Get owner references (to identify which workload owns this pod)
+                owner_references = metadata.get("ownerReferences", [])
+                owner_kind = "N/A"
+                owner_name = "N/A"
+                if owner_references:
+                    owner = owner_references[0]
+                    owner_kind = owner.get("kind", "N/A")
+                    owner_name = owner.get("name", "N/A")
+
+                parsed_pod = {
+                    "name": metadata.get("name", "Unknown"),
+                    "namespace": metadata.get("namespace", "default"),
+                    "phase": phase,
+                    "ready_containers": ready_containers,
+                    "total_containers": total_containers,
+                    "restart_count": restart_count,
+                    "node_name": node_name,
+                    "pod_ip": pod_ip,
+                    "creation_timestamp": creation_timestamp,
+                    "labels": labels,
+                    "owner_kind": owner_kind,
+                    "owner_name": owner_name,
+                    "uid": metadata.get("uid", ""),
+                }
+
+                parsed_pods.append(parsed_pod)
+
+            except Exception as ex:
+                _LOGGER.warning("Failed to parse pod data: %s", ex)
+                continue
+
+        return parsed_pods
+
     async def get_nodes_count(self) -> int:
         """Get the count of nodes in the cluster."""
         try:

--- a/custom_components/kubernetes/sensor.py
+++ b/custom_components/kubernetes/sensor.py
@@ -57,6 +57,26 @@ async def async_setup_entry(
                 node_sensor.unique_id,
             )
 
+        # Create individual sensors for each Kubernetes pod
+        pods_data = coordinator.get_all_pods_data()
+        _LOGGER.debug("Creating pod sensors for pods: %s", list(pods_data.keys()))
+
+        pod_sensors_created = 0
+        for pod_key, pod_data in pods_data.items():
+            namespace = pod_data.get("namespace", "default")
+            pod_name = pod_data.get("name", "unknown")
+            pod_sensor = KubernetesPodSensor(
+                coordinator, client, config_entry, namespace, pod_name
+            )
+            sensors.append(pod_sensor)
+            pod_sensors_created += 1
+            _LOGGER.debug(
+                "Created pod sensor for: %s/%s (unique_id: %s)",
+                namespace,
+                pod_name,
+                pod_sensor.unique_id,
+            )
+
         async_add_entities(sensors)
 
         # Store the add_entities callback for dynamic entity management
@@ -73,7 +93,7 @@ async def async_setup_entry(
         def _async_add_new_entities() -> None:
             """Add new entities when new resources are discovered."""
             hass.async_create_task(
-                _async_discover_and_add_new_node_sensors(
+                _async_discover_and_add_new_sensors(
                     hass, config_entry, coordinator, client
                 )
             )
@@ -82,22 +102,65 @@ async def async_setup_entry(
         coordinator.async_add_listener(_async_add_new_entities)
 
         _LOGGER.debug(
-            "Successfully set up %d Kubernetes sensors (including %d node sensors)",
+            "Successfully set up %d Kubernetes sensors (including %d node sensors, %d pod sensors)",
             len(sensors),
             node_sensors_created,
+            pod_sensors_created,
         )
     except Exception as ex:
         _LOGGER.error("Failed to set up Kubernetes sensors: %s", ex)
         raise
 
 
-async def _async_discover_and_add_new_node_sensors(
+def _discover_new_node_sensors(
+    coordinator: KubernetesDataCoordinator,
+    client: Any,
+    config_entry: ConfigEntry,
+    existing_unique_ids: set[str],
+) -> list[KubernetesNodeSensor]:
+    """Discover new node sensors."""
+    new_entities = []
+    if coordinator.data and "nodes" in coordinator.data:
+        for node_name in coordinator.data["nodes"]:
+            unique_id = f"{config_entry.entry_id}_node_{node_name}"
+            if unique_id not in existing_unique_ids:
+                _LOGGER.info("Adding new node sensor for: %s", node_name)
+                new_entities.append(
+                    KubernetesNodeSensor(coordinator, client, config_entry, node_name)
+                )
+    return new_entities
+
+
+def _discover_new_pod_sensors(
+    coordinator: KubernetesDataCoordinator,
+    client: Any,
+    config_entry: ConfigEntry,
+    existing_unique_ids: set[str],
+) -> list[KubernetesPodSensor]:
+    """Discover new pod sensors."""
+    new_entities = []
+    if coordinator.data and "pods" in coordinator.data:
+        for pod_key, pod_data in coordinator.data["pods"].items():
+            namespace = pod_data.get("namespace", "default")
+            pod_name = pod_data.get("name", "unknown")
+            unique_id = f"{config_entry.entry_id}_pod_{namespace}_{pod_name}"
+            if unique_id not in existing_unique_ids:
+                _LOGGER.info("Adding new pod sensor for: %s/%s", namespace, pod_name)
+                new_entities.append(
+                    KubernetesPodSensor(
+                        coordinator, client, config_entry, namespace, pod_name
+                    )
+                )
+    return new_entities
+
+
+async def _async_discover_and_add_new_sensors(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
     coordinator: KubernetesDataCoordinator,
     client: Any,
 ) -> None:
-    """Discover and add new node sensors for newly discovered Kubernetes nodes."""
+    """Discover and add new sensors for newly discovered Kubernetes resources."""
     try:
         entity_registry = async_get_entity_registry(hass)
 
@@ -106,7 +169,7 @@ async def _async_discover_and_add_new_node_sensors(
         add_entities_callback = sensor_data.get("sensor_add_entities")
         if not add_entities_callback:
             _LOGGER.warning(
-                "No add_entities callback found for dynamic node sensor management"
+                "No add_entities callback found for dynamic sensor management"
             )
             return
 
@@ -118,29 +181,28 @@ async def _async_discover_and_add_new_node_sensors(
             entity.unique_id for entity in existing_entities if entity.unique_id
         }
 
+        # Discover new sensors
         new_entities = []
-
-        # Check for new nodes
-        if coordinator.data and "nodes" in coordinator.data:
-            for node_name in coordinator.data["nodes"]:
-                unique_id = f"{config_entry.entry_id}_node_{node_name}"
-                if unique_id not in existing_unique_ids:
-                    _LOGGER.info("Adding new node sensor for: %s", node_name)
-                    new_entities.append(
-                        KubernetesNodeSensor(
-                            coordinator, client, config_entry, node_name
-                        )
-                    )
+        new_entities.extend(
+            _discover_new_node_sensors(
+                coordinator, client, config_entry, existing_unique_ids
+            )
+        )
+        new_entities.extend(
+            _discover_new_pod_sensors(
+                coordinator, client, config_entry, existing_unique_ids
+            )
+        )
 
         # Add new entities if any were found
         if new_entities:
-            _LOGGER.info("Adding %d new node sensors", len(new_entities))
+            _LOGGER.info("Adding %d new sensors", len(new_entities))
             add_entities_callback(new_entities)
         else:
-            _LOGGER.debug("No new node sensors to add")
+            _LOGGER.debug("No new sensors to add")
 
     except Exception as ex:
-        _LOGGER.error("Failed to discover and add new node sensors: %s", ex)
+        _LOGGER.error("Failed to discover and add new sensors: %s", ex)
 
 
 class KubernetesBaseSensor(SensorEntity):
@@ -447,3 +509,90 @@ class KubernetesNodeSensor(KubernetesBaseSensor):
             # The base class handles coordinator updates
         except Exception as ex:
             _LOGGER.error("Failed to update node sensor %s: %s", self.node_name, ex)
+
+
+class KubernetesPodSensor(KubernetesBaseSensor):
+    """Sensor for individual Kubernetes pod with detailed information."""
+
+    def __init__(
+        self,
+        coordinator: KubernetesDataCoordinator,
+        client,
+        config_entry: ConfigEntry,
+        namespace: str,
+        pod_name: str,
+    ) -> None:
+        """Initialize the pod sensor."""
+        super().__init__(coordinator, client, config_entry)
+        self.namespace = namespace
+        self.pod_name = pod_name
+        self._attr_name = f"{pod_name}"
+        self._attr_unique_id = f"{config_entry.entry_id}_pod_{namespace}_{pod_name}"
+        self._attr_native_unit_of_measurement = None
+        self._attr_icon = "mdi:cube"
+        # Override state class since this sensor returns string values, not measurements
+        self._attr_state_class = None
+
+        _LOGGER.debug(
+            "Initialized pod sensor for %s/%s with unique_id: %s",
+            namespace,
+            pod_name,
+            self._attr_unique_id,
+        )
+
+    @property
+    def native_value(self) -> str:
+        """Return the native value of the sensor (pod phase)."""
+        pod_data = self.coordinator.get_pod_data(self.namespace, self.pod_name)
+        if pod_data:
+            phase = pod_data.get("phase", "Unknown")
+            _LOGGER.debug(
+                "Pod %s/%s native_value: %s", self.namespace, self.pod_name, phase
+            )
+            return phase
+        _LOGGER.debug(
+            "Pod %s/%s has no data, returning Unknown", self.namespace, self.pod_name
+        )
+        return "Unknown"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return additional state attributes for the pod."""
+        pod_data = self.coordinator.get_pod_data(self.namespace, self.pod_name)
+        if not pod_data:
+            return {}
+
+        attributes = {
+            "namespace": pod_data.get("namespace", "N/A"),
+            "ready_containers": pod_data.get("ready_containers", 0),
+            "total_containers": pod_data.get("total_containers", 0),
+            "restart_count": pod_data.get("restart_count", 0),
+            "node_name": pod_data.get("node_name", "N/A"),
+            "pod_ip": pod_data.get("pod_ip", "N/A"),
+            "creation_timestamp": pod_data.get("creation_timestamp", "N/A"),
+            "owner_kind": pod_data.get("owner_kind", "N/A"),
+            "owner_name": pod_data.get("owner_name", "N/A"),
+            "uid": pod_data.get("uid", "N/A"),
+        }
+
+        # Add labels as individual attributes (flattened)
+        labels = pod_data.get("labels", {})
+        for key, value in labels.items():
+            # Replace special characters in label keys to make them valid attribute names
+            attr_key = f"label_{key.replace('/', '_').replace('.', '_')}"
+            attributes[attr_key] = value
+
+        return attributes
+
+    async def async_update(self) -> None:
+        """Update the pod sensor state."""
+        try:
+            await super().async_update()
+            # The base class handles coordinator updates
+        except Exception as ex:
+            _LOGGER.error(
+                "Failed to update pod sensor %s/%s: %s",
+                self.namespace,
+                self.pod_name,
+                ex,
+            )

--- a/docs/ENTITIES.md
+++ b/docs/ENTITIES.md
@@ -22,6 +22,14 @@ The integration creates a separate sensor for each Kubernetes node in the cluste
 |--------|-------------|---------------|------|
 | **Node [node-name]** | Individual node status and information | `Ready` / `NotReady` / `Unknown` | - |
 
+### Individual Pod Sensors
+
+The integration creates a separate sensor for each Kubernetes pod in the monitored namespace(s):
+
+| Sensor | Description | Example Value | Unit |
+|--------|-------------|---------------|------|
+| **Pod [pod-name]** | Individual pod phase and information | `Running` / `Pending` / `Failed` / `Succeeded` / `Unknown` | - |
+
 #### Node Sensor Attributes
 
 Each node sensor provides comprehensive information about the node:
@@ -39,6 +47,24 @@ Each node sensor provides comprehensive information about the node:
 | **kubelet_version** | Kubelet version | `v1.25.4` |
 | **schedulable** | Whether the node can schedule new pods | `true` / `false` |
 | **creation_timestamp** | When the node was created | `2023-01-01T00:00:00Z` |
+
+#### Pod Sensor Attributes
+
+Each pod sensor provides comprehensive information about the pod:
+
+| Attribute | Description | Example Value |
+|-----------|-------------|---------------|
+| **namespace** | Kubernetes namespace where the pod is located | `default` |
+| **ready_containers** | Number of ready containers in the pod | `2` |
+| **total_containers** | Total number of containers in the pod | `2` |
+| **restart_count** | Total number of container restarts | `0` |
+| **node_name** | Name of the node where the pod is running | `worker-node-1` |
+| **pod_ip** | IP address of the pod | `10.244.1.5` |
+| **creation_timestamp** | When the pod was created | `2023-01-01T00:00:00Z` |
+| **owner_kind** | Type of resource that owns this pod | `ReplicaSet` |
+| **owner_name** | Name of the resource that owns this pod | `my-app-7d4b8c9f6b` |
+| **uid** | Unique identifier of the pod | `a1b2c3d4-e5f6-7890-abcd-ef1234567890` |
+| **label_[key]** | Pod labels as individual attributes | `app=my-app`, `version=v1.0` |
 
 ### Sensor Attributes
 
@@ -108,6 +134,7 @@ Entities are automatically named using the following patterns:
 - **Sensors**: `sensor.kubernetes_[cluster_name]_[metric_type]`
 - **Binary Sensors**: `binary_sensor.kubernetes_[cluster_name]_cluster_health`
 - **Switches**: `switch.kubernetes_[cluster_name]_[resource_type]_[resource_name]`
+- **Pod Sensors**: `sensor.kubernetes_[cluster_name]_[pod_name]`
 
 ## Dynamic Entity Discovery
 
@@ -116,6 +143,7 @@ The integration automatically discovers and creates entities for:
 - All deployments in monitored namespaces
 - All statefulsets in monitored namespaces
 - All cronjobs in monitored namespaces
+- Individual Kubernetes pods in monitored namespaces
 - Individual Kubernetes nodes in the cluster
 - Cluster-wide metrics (pods, nodes, deployments, statefulsets, cronjobs count)
 - Overall cluster health
@@ -128,3 +156,37 @@ Entities are automatically added when new resources are created and removed when
 - **Dynamic Updates**: Node information is refreshed during regular coordinator updates
 - **Automatic Cleanup**: Node sensors are automatically removed when nodes are deleted from the cluster
 - **Entity Naming**: Node entities use the format `sensor.kubernetes_node_[node_name]`
+
+### Pod Entity Management
+
+- **Automatic Creation**: Pod sensors are automatically created for each pod discovered during integration setup
+- **Dynamic Updates**: Pod information is refreshed during regular coordinator updates
+- **Automatic Cleanup**: Pod sensors are automatically removed when pods are deleted from the cluster
+- **Entity Naming**: Pod entities use the format `sensor.kubernetes_[pod_name]`
+- **Namespace Support**: Pods are tracked by both namespace and name for proper identification
+- **Phase Tracking**: Pod sensors show the current phase (Running, Pending, Failed, Succeeded, etc.)
+- **Container Status**: Detailed information about container readiness and restart counts
+- **Owner Information**: Shows which workload (Deployment, StatefulSet, etc.) owns the pod
+
+## Using Pod Entities with Auto-Entities
+
+The pod entities are perfect for use with the [auto-entities](https://github.com/thomasloven/lovelace-auto-entities) card to create dynamic dashboards. Here's an example configuration to show pods that are not in a Running or Completed phase:
+
+```yaml
+type: custom:auto-entities
+card:
+  type: entities
+  title: "Pods with Issues"
+filter:
+  include:
+    - entity_id: sensor.kubernetes_*
+      state:
+        - "Pending"
+        - "Failed"
+        - "Unknown"
+  exclude:
+    - state: "Running"
+    - state: "Succeeded"
+```
+
+This configuration will automatically populate a card with all pod entities that are in a problematic state, making it easy to monitor and troubleshoot your Kubernetes cluster.

--- a/tests/test_kubernetes_client.py
+++ b/tests/test_kubernetes_client.py
@@ -1139,3 +1139,182 @@ class TestKubernetesClientCronJobOperations:
                 client._resume_cronjob_aiohttp.assert_called_once_with(
                     "test-cronjob", "other-namespace"
                 )
+
+
+class TestKubernetesClientGetPods:
+    """Test cases for Kubernetes client get_pods method."""
+
+    @pytest.mark.asyncio
+    async def test_get_pods_success(self, mock_client):
+        """Test successful get_pods call."""
+        # Mock the aiohttp response
+        mock_response_data = {
+            "items": [
+                {
+                    "metadata": {
+                        "name": "test-pod-1",
+                        "namespace": "default",
+                        "uid": "pod-uid-1",
+                        "creationTimestamp": "2023-01-01T00:00:00Z",
+                        "labels": {"app": "test-app", "version": "v1.0"},
+                    },
+                    "spec": {"nodeName": "worker-node-1"},
+                    "status": {
+                        "phase": "Running",
+                        "podIP": "10.244.1.5",
+                        "containerStatuses": [
+                            {"ready": True, "restartCount": 0},
+                            {"ready": True, "restartCount": 0},
+                        ],
+                    },
+                },
+                {
+                    "metadata": {
+                        "name": "test-pod-2",
+                        "namespace": "default",
+                        "uid": "pod-uid-2",
+                        "creationTimestamp": "2023-01-01T00:00:00Z",
+                        "labels": {"app": "test-app-2"},
+                        "ownerReferences": [
+                            {"kind": "ReplicaSet", "name": "test-app-2-7d4b8c9f6b"}
+                        ],
+                    },
+                    "spec": {"nodeName": "worker-node-2"},
+                    "status": {
+                        "phase": "Pending",
+                        "podIP": "10.244.1.6",
+                        "containerStatuses": [{"ready": False, "restartCount": 1}],
+                    },
+                },
+            ]
+        }
+
+        with patch("aiohttp.ClientSession.get") as mock_get:
+            mock_response = AsyncMock()
+            mock_response.status = 200
+            mock_response.json = AsyncMock(return_value=mock_response_data)
+            mock_get.return_value.__aenter__.return_value = mock_response
+
+            result = await mock_client.get_pods()
+
+            assert len(result) == 2
+
+            # Check first pod
+            pod1 = result[0]
+            assert pod1["name"] == "test-pod-1"
+            assert pod1["namespace"] == "default"
+            assert pod1["phase"] == "Running"
+            assert pod1["ready_containers"] == 2
+            assert pod1["total_containers"] == 2
+            assert pod1["restart_count"] == 0
+            assert pod1["node_name"] == "worker-node-1"
+            assert pod1["pod_ip"] == "10.244.1.5"
+            assert pod1["owner_kind"] == "N/A"
+            assert pod1["owner_name"] == "N/A"
+            assert pod1["labels"]["app"] == "test-app"
+            assert pod1["labels"]["version"] == "v1.0"
+
+            # Check second pod
+            pod2 = result[1]
+            assert pod2["name"] == "test-pod-2"
+            assert pod2["namespace"] == "default"
+            assert pod2["phase"] == "Pending"
+            assert pod2["ready_containers"] == 0
+            assert pod2["total_containers"] == 1
+            assert pod2["restart_count"] == 1
+            assert pod2["node_name"] == "worker-node-2"
+            assert pod2["pod_ip"] == "10.244.1.6"
+            assert pod2["owner_kind"] == "ReplicaSet"
+            assert pod2["owner_name"] == "test-app-2-7d4b8c9f6b"
+
+    @pytest.mark.asyncio
+    async def test_get_pods_empty_response(self, mock_client):
+        """Test get_pods with empty response."""
+        mock_response_data = {"items": []}
+
+        with patch("aiohttp.ClientSession.get") as mock_get:
+            mock_response = AsyncMock()
+            mock_response.status = 200
+            mock_response.json = AsyncMock(return_value=mock_response_data)
+            mock_get.return_value.__aenter__.return_value = mock_response
+
+            result = await mock_client.get_pods()
+            assert result == []
+
+    @pytest.mark.asyncio
+    async def test_get_pods_http_error(self, mock_client):
+        """Test get_pods with HTTP error."""
+        with patch("aiohttp.ClientSession.get") as mock_get:
+            mock_response = AsyncMock()
+            mock_response.status = 500
+            mock_get.return_value.__aenter__.return_value = mock_response
+
+            result = await mock_client.get_pods()
+            assert result == []
+
+    @pytest.mark.asyncio
+    async def test_get_pods_connection_error(self, mock_client):
+        """Test get_pods with connection error."""
+        with patch(
+            "aiohttp.ClientSession.get",
+            side_effect=aiohttp.ClientError("Connection error"),
+        ):
+            result = await mock_client.get_pods()
+            assert result == []
+
+    @pytest.mark.asyncio
+    async def test_get_pods_all_namespaces(self, mock_client):
+        """Test get_pods with monitor_all_namespaces enabled."""
+        mock_client.monitor_all_namespaces = True
+
+        mock_response_data = {"items": []}
+
+        with patch("aiohttp.ClientSession.get") as mock_get:
+            mock_response = AsyncMock()
+            mock_response.status = 200
+            mock_response.json = AsyncMock(return_value=mock_response_data)
+            mock_get.return_value.__aenter__.return_value = mock_response
+
+            await mock_client.get_pods()
+
+            # Verify the correct URL was called (all namespaces)
+            mock_get.assert_called_once()
+            call_args = mock_get.call_args
+            assert "/api/v1/pods" in call_args[1]["url"]
+
+    def test_parse_pods_data(self, mock_client):
+        """Test _parse_pods_data method."""
+        raw_pods = [
+            {
+                "metadata": {
+                    "name": "test-pod",
+                    "namespace": "default",
+                    "uid": "pod-uid",
+                    "creationTimestamp": "2023-01-01T00:00:00Z",
+                    "labels": {"app": "test-app"},
+                },
+                "spec": {"nodeName": "worker-node-1"},
+                "status": {
+                    "phase": "Running",
+                    "podIP": "10.244.1.5",
+                    "containerStatuses": [
+                        {"ready": True, "restartCount": 0},
+                        {"ready": False, "restartCount": 1},
+                    ],
+                },
+            }
+        ]
+
+        result = mock_client._parse_pods_data(raw_pods)
+
+        assert len(result) == 1
+        pod = result[0]
+        assert pod["name"] == "test-pod"
+        assert pod["namespace"] == "default"
+        assert pod["phase"] == "Running"
+        assert pod["ready_containers"] == 1
+        assert pod["total_containers"] == 2
+        assert pod["restart_count"] == 1
+        assert pod["node_name"] == "worker-node-1"
+        assert pod["pod_ip"] == "10.244.1.5"
+        assert pod["labels"]["app"] == "test-app"

--- a/tests/test_sensors.py
+++ b/tests/test_sensors.py
@@ -27,6 +27,7 @@ from custom_components.kubernetes.sensor import (
     KubernetesDeploymentsSensor,
     KubernetesNodeSensor,
     KubernetesNodesSensor,
+    KubernetesPodSensor,
     KubernetesPodsSensor,
     KubernetesStatefulSetsSensor,
 )
@@ -928,3 +929,152 @@ class TestDynamicNodeSensorDiscovery:
             await _async_discover_and_add_new_node_sensors(
                 mock_hass, mock_config_entry, mock_coordinator, mock_client
             )
+
+
+class TestKubernetesPodSensor:
+    """Test cases for KubernetesPodSensor."""
+
+    def test_pod_sensor_initialization(
+        self, mock_hass, mock_config_entry, mock_coordinator, mock_client
+    ):
+        """Test pod sensor initialization."""
+        namespace = "default"
+        pod_name = "test-pod"
+
+        sensor = KubernetesPodSensor(
+            mock_coordinator, mock_client, mock_config_entry, namespace, pod_name
+        )
+
+        assert sensor.namespace == namespace
+        assert sensor.pod_name == pod_name
+        assert sensor.name == pod_name
+        assert (
+            sensor.unique_id
+            == f"{mock_config_entry.entry_id}_pod_{namespace}_{pod_name}"
+        )
+        assert sensor.icon == "mdi:cube"
+        assert sensor.state_class is None
+
+    def test_pod_sensor_native_value_with_data(
+        self, mock_hass, mock_config_entry, mock_coordinator, mock_client
+    ):
+        """Test pod sensor native value when data is available."""
+        namespace = "default"
+        pod_name = "test-pod"
+
+        # Mock coordinator data
+        mock_coordinator.get_pod_data.return_value = {
+            "name": pod_name,
+            "namespace": namespace,
+            "phase": "Running",
+            "ready_containers": 2,
+            "total_containers": 2,
+            "restart_count": 0,
+            "node_name": "worker-node-1",
+            "pod_ip": "10.244.1.5",
+            "creation_timestamp": "2023-01-01T00:00:00Z",
+            "owner_kind": "ReplicaSet",
+            "owner_name": "test-app-7d4b8c9f6b",
+            "uid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "labels": {"app": "test-app", "version": "v1.0"},
+        }
+
+        sensor = KubernetesPodSensor(
+            mock_coordinator, mock_client, mock_config_entry, namespace, pod_name
+        )
+
+        assert sensor.native_value == "Running"
+
+    def test_pod_sensor_native_value_no_data(
+        self, mock_hass, mock_config_entry, mock_coordinator, mock_client
+    ):
+        """Test pod sensor native value when no data is available."""
+        namespace = "default"
+        pod_name = "test-pod"
+
+        # Mock coordinator to return no data
+        mock_coordinator.get_pod_data.return_value = None
+
+        sensor = KubernetesPodSensor(
+            mock_coordinator, mock_client, mock_config_entry, namespace, pod_name
+        )
+
+        assert sensor.native_value == "Unknown"
+
+    def test_pod_sensor_extra_state_attributes(
+        self, mock_hass, mock_config_entry, mock_coordinator, mock_client
+    ):
+        """Test pod sensor extra state attributes."""
+        namespace = "default"
+        pod_name = "test-pod"
+
+        # Mock coordinator data
+        mock_coordinator.get_pod_data.return_value = {
+            "name": pod_name,
+            "namespace": namespace,
+            "phase": "Running",
+            "ready_containers": 2,
+            "total_containers": 2,
+            "restart_count": 0,
+            "node_name": "worker-node-1",
+            "pod_ip": "10.244.1.5",
+            "creation_timestamp": "2023-01-01T00:00:00Z",
+            "owner_kind": "ReplicaSet",
+            "owner_name": "test-app-7d4b8c9f6b",
+            "uid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "labels": {"app": "test-app", "version": "v1.0"},
+        }
+
+        sensor = KubernetesPodSensor(
+            mock_coordinator, mock_client, mock_config_entry, namespace, pod_name
+        )
+
+        attributes = sensor.extra_state_attributes
+
+        assert attributes["namespace"] == namespace
+        assert attributes["ready_containers"] == 2
+        assert attributes["total_containers"] == 2
+        assert attributes["restart_count"] == 0
+        assert attributes["node_name"] == "worker-node-1"
+        assert attributes["pod_ip"] == "10.244.1.5"
+        assert attributes["creation_timestamp"] == "2023-01-01T00:00:00Z"
+        assert attributes["owner_kind"] == "ReplicaSet"
+        assert attributes["owner_name"] == "test-app-7d4b8c9f6b"
+        assert attributes["uid"] == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        assert attributes["label_app"] == "test-app"
+        assert attributes["label_version"] == "v1.0"
+
+    def test_pod_sensor_extra_state_attributes_no_data(
+        self, mock_hass, mock_config_entry, mock_coordinator, mock_client
+    ):
+        """Test pod sensor extra state attributes when no data is available."""
+        namespace = "default"
+        pod_name = "test-pod"
+
+        # Mock coordinator to return no data
+        mock_coordinator.get_pod_data.return_value = None
+
+        sensor = KubernetesPodSensor(
+            mock_coordinator, mock_client, mock_config_entry, namespace, pod_name
+        )
+
+        attributes = sensor.extra_state_attributes
+        assert attributes == {}
+
+    async def test_pod_sensor_async_update(
+        self, mock_hass, mock_config_entry, mock_coordinator, mock_client
+    ):
+        """Test pod sensor async update."""
+        namespace = "default"
+        pod_name = "test-pod"
+
+        sensor = KubernetesPodSensor(
+            mock_coordinator, mock_client, mock_config_entry, namespace, pod_name
+        )
+
+        # Mock the parent class async_update method
+        with patch.object(
+            sensor.__class__.__bases__[0], "async_update"
+        ) as mock_parent_update:
+            await sensor.async_update()
+            mock_parent_update.assert_called_once()


### PR DESCRIPTION
- Add individual pod sensor entities for each Kubernetes pod
- Pod phase as main state (Running, Pending, Failed, Succeeded, Unknown)
- Comprehensive pod attributes including container status, restart counts, node info
- Support for pod labels as individual entity attributes
- Automatic discovery and cleanup of pod entities
- Enhanced coordinator to fetch and store pod data
- Updated entity management to handle pod entities
- Added comprehensive unit tests for pod functionality
- Updated documentation with pod entity details and auto-entities examples
- Refactored sensor discovery functions to reduce complexity

Closes #59