### PR TITLE
style(frontend): reformat source with prettier 3.9 and rebuild bundle

### DIFF
--- a/custom_components/kubernetes/frontend/kubernetes-panel.js
+++ b/custom_components/kubernetes/frontend/kubernetes-panel.js
@@ -1137,16 +1137,16 @@ var K8sOverview = class K8sOverview extends i {
             </span>
           </div>
           ${totalAlerts > 0 ? this._renderAlerts(cluster.alerts) : b`
-                <div class="no-alerts">
-                  <ha-icon icon="mdi:check-circle"></ha-icon>
-                  <div class="no-alerts-text">
-                    <div class="no-alerts-title">No active alerts</div>
-                    <div class="no-alerts-detail">
-                      All nodes, workloads, and pods are operating normally.
+                  <div class="no-alerts">
+                    <ha-icon icon="mdi:check-circle"></ha-icon>
+                    <div class="no-alerts-text">
+                      <div class="no-alerts-title">No active alerts</div>
+                      <div class="no-alerts-detail">
+                        All nodes, workloads, and pods are operating normally.
+                      </div>
                     </div>
                   </div>
-                </div>
-              `}
+                `}
         </div>
 
         ${this._renderNamespaceSection(cluster)}
@@ -1704,9 +1704,9 @@ var K8sNodesTable = class K8sNodesTable extends i {
             ${node.name}
             ${!node.schedulable ? b`<span class="badge badge-unschedulable">Unschedulable</span>` : A}
             ${conditions.length > 0 ? b`<span class="badge badge-condition"
-                  >${conditions.length}
-                  condition${conditions.length > 1 ? "s" : ""}</span
-                >` : A}
+                    >${conditions.length}
+                    condition${conditions.length > 1 ? "s" : ""}</span
+                  >` : A}
           </div>
           <span
             class="badge ${node.status === "Ready" ? "badge-ready" : "badge-not-ready"}"
@@ -1716,29 +1716,30 @@ var K8sNodesTable = class K8sNodesTable extends i {
           <span class="node-ip">${node.internal_ip}</span>
           <div class="node-resources">
             ${hasMetrics ? b`
-                  <div class="resource-bar-container" title="CPU usage">
-                    <span class="resource-label">CPU</span>
-                    <div class="resource-bar">
-                      <div
-                        class="resource-bar-fill ${cpuPercent > 80 ? "bar-warn" : ""}"
-                        style="width: ${Math.min(cpuPercent, 100)}%"
-                      ></div>
+                    <div class="resource-bar-container" title="CPU usage">
+                      <span class="resource-label">CPU</span>
+                      <div class="resource-bar">
+                        <div
+                          class="resource-bar-fill ${cpuPercent > 80 ? "bar-warn" : ""}"
+                          style="width: ${Math.min(cpuPercent, 100)}%"
+                        ></div>
+                      </div>
+                      <span>${cpuPercent}%</span>
                     </div>
-                    <span>${cpuPercent}%</span>
-                  </div>
-                  <div class="resource-bar-container" title="Memory usage">
-                    <span class="resource-label">MEM</span>
-                    <div class="resource-bar">
-                      <div
-                        class="resource-bar-fill ${memPercent > 80 ? "bar-warn" : ""}"
-                        style="width: ${Math.min(memPercent, 100)}%"
-                      ></div>
+                    <div class="resource-bar-container" title="Memory usage">
+                      <span class="resource-label">MEM</span>
+                      <div class="resource-bar">
+                        <div
+                          class="resource-bar-fill ${memPercent > 80 ? "bar-warn" : ""}"
+                          style="width: ${Math.min(memPercent, 100)}%"
+                        ></div>
+                      </div>
+                      <span>${memPercent}%</span>
                     </div>
-                    <span>${memPercent}%</span>
-                  </div>
-                ` : b`<span
-                  >${node.cpu_cores} CPU &middot; ${node.memory_capacity_gib} GiB</span
-                >`}
+                  ` : b`<span
+                    >${node.cpu_cores} CPU &middot; ${node.memory_capacity_gib}
+                    GiB</span
+                  >`}
           </div>
           <span class="node-age">${this._formatAge(node.creation_timestamp)}</span>
         </div>
@@ -1765,13 +1766,13 @@ var K8sNodesTable = class K8sNodesTable extends i {
             <span class="detail-value">${node.cpu_cores}</span>
           </div>
           ${hasMetrics ? b`
-                <div class="detail-item">
-                  <span class="detail-label">CPU Usage</span>
-                  <span class="detail-value"
-                    >${node.cpu_usage_millicores}m / ${node.cpu_cores * 1e3}m</span
-                  >
-                </div>
-              ` : A}
+                  <div class="detail-item">
+                    <span class="detail-label">CPU Usage</span>
+                    <span class="detail-value"
+                      >${node.cpu_usage_millicores}m / ${node.cpu_cores * 1e3}m</span
+                    >
+                  </div>
+                ` : A}
           <div class="detail-item">
             <span class="detail-label">Memory Capacity</span>
             <span class="detail-value">${node.memory_capacity_gib} GiB</span>
@@ -1781,13 +1782,13 @@ var K8sNodesTable = class K8sNodesTable extends i {
             <span class="detail-value">${node.memory_allocatable_gib} GiB</span>
           </div>
           ${hasMetrics ? b`
-                <div class="detail-item">
-                  <span class="detail-label">Memory Usage</span>
-                  <span class="detail-value"
-                    >${memUsageGib} / ${node.memory_capacity_gib} GiB</span
-                  >
-                </div>
-              ` : A}
+                  <div class="detail-item">
+                    <span class="detail-label">Memory Usage</span>
+                    <span class="detail-value"
+                      >${memUsageGib} / ${node.memory_capacity_gib} GiB</span
+                    >
+                  </div>
+                ` : A}
           <div class="detail-item">
             <span class="detail-label">OS Image</span>
             <span class="detail-value">${node.os_image}</span>
@@ -1814,14 +1815,14 @@ var K8sNodesTable = class K8sNodesTable extends i {
           </div>
         </div>
         ${conditions.length > 0 ? b`
-              <div class="conditions-row">
-                ${conditions.map((c) => b`
-                    <span class="badge badge-condition">
-                      ${CONDITION_LABELS[c] || c}
-                    </span>
-                  `)}
-              </div>
-            ` : A}
+                <div class="conditions-row">
+                  ${conditions.map((c) => b`
+                      <span class="badge badge-condition">
+                        ${CONDITION_LABELS[c] || c}
+                      </span>
+                    `)}
+                </div>
+              ` : A}
       </div>
     `;
 	}
@@ -2389,57 +2390,63 @@ var K8sPodsTable = class K8sPodsTable extends i {
         <div class="pod-count">${filtered.length}/${cluster.pods.length} pods</div>
 
         ${filtered.length === 0 ? b`<div class="empty">No pods match your filters.</div>` : b`
-              <ha-card>
-                <div class="table-wrapper">
-                  <table class="pods-table">
-                    <thead>
-                      <tr>
-                        <th @click=${() => this._handleSort("namespace")}>
-                          Namespace
-                          ${this._sortIcon("namespace") ? b`<ha-icon
-                                icon=${this._sortIcon("namespace")}
-                              ></ha-icon>` : A}
-                        </th>
-                        <th @click=${() => this._handleSort("name")}>
-                          Name
-                          ${this._sortIcon("name") ? b`<ha-icon icon=${this._sortIcon("name")}></ha-icon>` : A}
-                        </th>
-                        <th @click=${() => this._handleSort("phase")}>
-                          Phase
-                          ${this._sortIcon("phase") ? b`<ha-icon icon=${this._sortIcon("phase")}></ha-icon>` : A}
-                        </th>
-                        <th>Ready</th>
-                        <th @click=${() => this._handleSort("restarts")}>
-                          Restarts
-                          ${this._sortIcon("restarts") ? b`<ha-icon
-                                icon=${this._sortIcon("restarts")}
-                              ></ha-icon>` : A}
-                        </th>
-                        <th
-                          class="col-node"
-                          @click=${() => this._handleSort("node_name")}
-                        >
-                          Node
-                          ${this._sortIcon("node_name") ? b`<ha-icon
-                                icon=${this._sortIcon("node_name")}
-                              ></ha-icon>` : A}
-                        </th>
-                        <th class="col-ip">IP</th>
-                        <th class="col-owner">Owner</th>
-                        <th @click=${() => this._handleSort("age")}>
-                          Age
-                          ${this._sortIcon("age") ? b`<ha-icon icon=${this._sortIcon("age")}></ha-icon>` : A}
-                        </th>
-                        <th class="col-actions"></th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      ${filtered.map((pod) => this._renderPodRow(cluster.entry_id, pod))}
-                    </tbody>
-                  </table>
-                </div>
-              </ha-card>
-            `}
+                <ha-card>
+                  <div class="table-wrapper">
+                    <table class="pods-table">
+                      <thead>
+                        <tr>
+                          <th @click=${() => this._handleSort("namespace")}>
+                            Namespace
+                            ${this._sortIcon("namespace") ? b`<ha-icon
+                                    icon=${this._sortIcon("namespace")}
+                                  ></ha-icon>` : A}
+                          </th>
+                          <th @click=${() => this._handleSort("name")}>
+                            Name
+                            ${this._sortIcon("name") ? b`<ha-icon
+                                    icon=${this._sortIcon("name")}
+                                  ></ha-icon>` : A}
+                          </th>
+                          <th @click=${() => this._handleSort("phase")}>
+                            Phase
+                            ${this._sortIcon("phase") ? b`<ha-icon
+                                    icon=${this._sortIcon("phase")}
+                                  ></ha-icon>` : A}
+                          </th>
+                          <th>Ready</th>
+                          <th @click=${() => this._handleSort("restarts")}>
+                            Restarts
+                            ${this._sortIcon("restarts") ? b`<ha-icon
+                                    icon=${this._sortIcon("restarts")}
+                                  ></ha-icon>` : A}
+                          </th>
+                          <th
+                            class="col-node"
+                            @click=${() => this._handleSort("node_name")}
+                          >
+                            Node
+                            ${this._sortIcon("node_name") ? b`<ha-icon
+                                    icon=${this._sortIcon("node_name")}
+                                  ></ha-icon>` : A}
+                          </th>
+                          <th class="col-ip">IP</th>
+                          <th class="col-owner">Owner</th>
+                          <th @click=${() => this._handleSort("age")}>
+                            Age
+                            ${this._sortIcon("age") ? b`<ha-icon
+                                    icon=${this._sortIcon("age")}
+                                  ></ha-icon>` : A}
+                          </th>
+                          <th class="col-actions"></th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        ${filtered.map((pod) => this._renderPodRow(cluster.entry_id, pod))}
+                      </tbody>
+                    </table>
+                  </div>
+                </ha-card>
+              `}
       </div>
     `;
 	}
@@ -2457,7 +2464,9 @@ var K8sPodsTable = class K8sPodsTable extends i {
         <td class="col-node">${pod.node_name}</td>
         <td class="col-ip mono">${pod.pod_ip}</td>
         <td class="col-owner">
-          ${pod.owner_kind !== "N/A" ? b`<span class="owner-info">${pod.owner_kind}/${pod.owner_name}</span>` : b`<span class="owner-info">-</span>`}
+          ${pod.owner_kind !== "N/A" ? b`<span class="owner-info"
+                  >${pod.owner_kind}/${pod.owner_name}</span
+                >` : b`<span class="owner-info">-</span>`}
         </td>
         <td>${this._formatAge(pod.creation_timestamp)}</td>
         <td>
@@ -2965,19 +2974,19 @@ var K8sWorkloads = class K8sWorkloads extends i {
 		if (!this._data?.clusters.length) return b`<div class="empty">No Kubernetes clusters configured.</div>`;
 		return b`
       ${this._actionError ? b`
-            <div class="action-error">
-              <span>${this._actionError}</span>
-              <button
-                class="dismiss-btn"
-                @click=${() => {
+              <div class="action-error">
+                <span>${this._actionError}</span>
+                <button
+                  class="dismiss-btn"
+                  @click=${() => {
 			this._actionError = null;
 		}}
-                title="Dismiss"
-              >
-                <ha-icon icon="mdi:close"></ha-icon>
-              </button>
-            </div>
-          ` : A}
+                  title="Dismiss"
+                >
+                  <ha-icon icon="mdi:close"></ha-icon>
+                </button>
+              </div>
+            ` : A}
       ${this._data.clusters.map((c) => this._renderCluster(c))}
     `;
 	}
@@ -3121,32 +3130,32 @@ var K8sWorkloads = class K8sWorkloads extends i {
           </span>
           <div class="workload-actions">
             ${d.replicas === 0 ? b`
-                  <button
-                    class="action-btn start"
-                    title="Start (scale to 1)"
-                    ?disabled=${busy}
-                    @click=${() => this._callService("start_workload", {
+                    <button
+                      class="action-btn start"
+                      title="Start (scale to 1)"
+                      ?disabled=${busy}
+                      @click=${() => this._callService("start_workload", {
 			workload_name: d.name,
 			namespace: d.namespace,
 			entry_id: entryId
 		}, actionKey)}
-                  >
-                    <ha-icon icon="mdi:play"></ha-icon>
-                  </button>
-                ` : b`
-                  <button
-                    class="action-btn stop"
-                    title="Stop (scale to 0)"
-                    ?disabled=${busy}
-                    @click=${() => this._callService("stop_workload", {
+                    >
+                      <ha-icon icon="mdi:play"></ha-icon>
+                    </button>
+                  ` : b`
+                    <button
+                      class="action-btn stop"
+                      title="Stop (scale to 0)"
+                      ?disabled=${busy}
+                      @click=${() => this._callService("stop_workload", {
 			workload_name: d.name,
 			namespace: d.namespace,
 			entry_id: entryId
 		}, actionKey)}
-                  >
-                    <ha-icon icon="mdi:stop"></ha-icon>
-                  </button>
-                `}
+                    >
+                      <ha-icon icon="mdi:stop"></ha-icon>
+                    </button>
+                  `}
             <button
               class="action-btn restart"
               title="Rolling restart"
@@ -3198,32 +3207,32 @@ var K8sWorkloads = class K8sWorkloads extends i {
           </span>
           <div class="workload-actions">
             ${s.replicas === 0 ? b`
-                  <button
-                    class="action-btn start"
-                    title="Start (scale to 1)"
-                    ?disabled=${busy}
-                    @click=${() => this._callService("start_workload", {
+                    <button
+                      class="action-btn start"
+                      title="Start (scale to 1)"
+                      ?disabled=${busy}
+                      @click=${() => this._callService("start_workload", {
 			workload_name: s.name,
 			namespace: s.namespace,
 			entry_id: entryId
 		}, actionKey)}
-                  >
-                    <ha-icon icon="mdi:play"></ha-icon>
-                  </button>
-                ` : b`
-                  <button
-                    class="action-btn stop"
-                    title="Stop (scale to 0)"
-                    ?disabled=${busy}
-                    @click=${() => this._callService("stop_workload", {
+                    >
+                      <ha-icon icon="mdi:play"></ha-icon>
+                    </button>
+                  ` : b`
+                    <button
+                      class="action-btn stop"
+                      title="Stop (scale to 0)"
+                      ?disabled=${busy}
+                      @click=${() => this._callService("stop_workload", {
 			workload_name: s.name,
 			namespace: s.namespace,
 			entry_id: entryId
 		}, actionKey)}
-                  >
-                    <ha-icon icon="mdi:stop"></ha-icon>
-                  </button>
-                `}
+                    >
+                      <ha-icon icon="mdi:stop"></ha-icon>
+                    </button>
+                  `}
             <button
               class="action-btn restart"
               title="Rolling restart"
@@ -3323,12 +3332,12 @@ var K8sWorkloads = class K8sWorkloads extends i {
           </div>
           <span class="schedule-info">${cj.schedule}</span>
           ${cj.active_jobs_count > 0 ? b`<span class="badge badge-active"
-                >${cj.active_jobs_count} active</span
-              >` : A}
+                  >${cj.active_jobs_count} active</span
+                >` : A}
           ${cj.suspend ? b`<span class="badge badge-suspended">Suspended</span>` : b`<span class="badge badge-healthy">Active</span>`}
           ${cj.last_schedule_time ? b`<span class="last-schedule"
-                >Last: ${this._formatAge(cj.last_schedule_time)}</span
-              >` : A}
+                  >Last: ${this._formatAge(cj.last_schedule_time)}</span
+                >` : A}
           <div class="workload-actions">
             <button
               class="action-btn start"
@@ -3383,8 +3392,8 @@ var K8sWorkloads = class K8sWorkloads extends i {
           ${hasFailed ? b`<span class="badge badge-failed">${j.failed} failed</span>` : A}
           ${isComplete ? b`<span class="badge badge-complete">Complete</span>` : A}
           ${j.start_time ? b`<span class="last-schedule"
-                >Started: ${this._formatAge(j.start_time)}</span
-              >` : A}
+                  >Started: ${this._formatAge(j.start_time)}</span
+                >` : A}
         </div>
       </ha-card>
     `;
@@ -3713,15 +3722,15 @@ var K8sSettings = class K8sSettings extends i {
           >
         </div>
         ${!entry.monitor_all_namespaces && entry.namespaces.length > 0 ? b`
-              <div class="setting-row">
-                <span class="setting-label">Selected</span>
-                <span class="setting-value">
-                  <div class="namespace-tags">
-                    ${entry.namespaces.map((ns) => b`<span class="ns-tag">${ns}</span>`)}
-                  </div>
-                </span>
-              </div>
-            ` : A}
+                <div class="setting-row">
+                  <span class="setting-label">Selected</span>
+                  <span class="setting-value">
+                    <div class="namespace-tags">
+                      ${entry.namespaces.map((ns) => b`<span class="ns-tag">${ns}</span>`)}
+                    </div>
+                  </span>
+                </div>
+              ` : A}
         <div class="setting-row">
           <span class="setting-label">Device Grouping</span>
           <span class="setting-value"

--- a/frontend/src/views/k8s-nodes-table.ts
+++ b/frontend/src/views/k8s-nodes-table.ts
@@ -473,9 +473,11 @@ export class K8sNodesTable extends LitElement {
 
     return html`
       <div class="cluster-section">
-        ${this._data!.clusters.length > 1
-          ? html`<div class="cluster-name">${cluster.cluster_name}</div>`
-          : nothing}
+        ${
+          this._data!.clusters.length > 1
+            ? html`<div class="cluster-name">${cluster.cluster_name}</div>`
+            : nothing
+        }
 
         <div class="filters">
           <input
@@ -504,14 +506,18 @@ export class K8sNodesTable extends LitElement {
 
         <div class="node-count">
           ${readyCount}/${cluster.nodes.length} nodes ready
-          ${filtered.length !== cluster.nodes.length
-            ? html` &middot; showing ${filtered.length}`
-            : nothing}
+          ${
+            filtered.length !== cluster.nodes.length
+              ? html` &middot; showing ${filtered.length}`
+              : nothing
+          }
         </div>
 
-        ${filtered.length === 0
-          ? html`<div class="empty">No nodes match your filters.</div>`
-          : filtered.map((node) => this._renderNode(cluster.entry_id, node))}
+        ${
+          filtered.length === 0
+            ? html`<div class="empty">No nodes match your filters.</div>`
+            : filtered.map((node) => this._renderNode(cluster.entry_id, node))
+        }
       </div>
     `;
   }
@@ -540,15 +546,19 @@ export class K8sNodesTable extends LitElement {
               icon=${expanded ? "mdi:chevron-down" : "mdi:chevron-right"}
             ></ha-icon>
             ${node.name}
-            ${!node.schedulable
-              ? html`<span class="badge badge-unschedulable">Unschedulable</span>`
-              : nothing}
-            ${conditions.length > 0
-              ? html`<span class="badge badge-condition"
-                  >${conditions.length}
-                  condition${conditions.length > 1 ? "s" : ""}</span
-                >`
-              : nothing}
+            ${
+              !node.schedulable
+                ? html`<span class="badge badge-unschedulable">Unschedulable</span>`
+                : nothing
+            }
+            ${
+              conditions.length > 0
+                ? html`<span class="badge badge-condition"
+                    >${conditions.length}
+                    condition${conditions.length > 1 ? "s" : ""}</span
+                  >`
+                : nothing
+            }
           </div>
           <span
             class="badge ${node.status === "Ready" ? "badge-ready" : "badge-not-ready"}"
@@ -557,32 +567,35 @@ export class K8sNodesTable extends LitElement {
           </span>
           <span class="node-ip">${node.internal_ip}</span>
           <div class="node-resources">
-            ${hasMetrics
-              ? html`
-                  <div class="resource-bar-container" title="CPU usage">
-                    <span class="resource-label">CPU</span>
-                    <div class="resource-bar">
-                      <div
-                        class="resource-bar-fill ${cpuPercent > 80 ? "bar-warn" : ""}"
-                        style="width: ${Math.min(cpuPercent, 100)}%"
-                      ></div>
+            ${
+              hasMetrics
+                ? html`
+                    <div class="resource-bar-container" title="CPU usage">
+                      <span class="resource-label">CPU</span>
+                      <div class="resource-bar">
+                        <div
+                          class="resource-bar-fill ${cpuPercent > 80 ? "bar-warn" : ""}"
+                          style="width: ${Math.min(cpuPercent, 100)}%"
+                        ></div>
+                      </div>
+                      <span>${cpuPercent}%</span>
                     </div>
-                    <span>${cpuPercent}%</span>
-                  </div>
-                  <div class="resource-bar-container" title="Memory usage">
-                    <span class="resource-label">MEM</span>
-                    <div class="resource-bar">
-                      <div
-                        class="resource-bar-fill ${memPercent > 80 ? "bar-warn" : ""}"
-                        style="width: ${Math.min(memPercent, 100)}%"
-                      ></div>
+                    <div class="resource-bar-container" title="Memory usage">
+                      <span class="resource-label">MEM</span>
+                      <div class="resource-bar">
+                        <div
+                          class="resource-bar-fill ${memPercent > 80 ? "bar-warn" : ""}"
+                          style="width: ${Math.min(memPercent, 100)}%"
+                        ></div>
+                      </div>
+                      <span>${memPercent}%</span>
                     </div>
-                    <span>${memPercent}%</span>
-                  </div>
-                `
-              : html`<span
-                  >${node.cpu_cores} CPU &middot; ${node.memory_capacity_gib} GiB</span
-                >`}
+                  `
+                : html`<span
+                    >${node.cpu_cores} CPU &middot; ${node.memory_capacity_gib}
+                    GiB</span
+                  >`
+            }
           </div>
           <span class="node-age">${this._formatAge(node.creation_timestamp)}</span>
         </div>
@@ -613,16 +626,18 @@ export class K8sNodesTable extends LitElement {
             <span class="detail-label">CPU Cores</span>
             <span class="detail-value">${node.cpu_cores}</span>
           </div>
-          ${hasMetrics
-            ? html`
-                <div class="detail-item">
-                  <span class="detail-label">CPU Usage</span>
-                  <span class="detail-value"
-                    >${node.cpu_usage_millicores}m / ${node.cpu_cores * 1000}m</span
-                  >
-                </div>
-              `
-            : nothing}
+          ${
+            hasMetrics
+              ? html`
+                  <div class="detail-item">
+                    <span class="detail-label">CPU Usage</span>
+                    <span class="detail-value"
+                      >${node.cpu_usage_millicores}m / ${node.cpu_cores * 1000}m</span
+                    >
+                  </div>
+                `
+              : nothing
+          }
           <div class="detail-item">
             <span class="detail-label">Memory Capacity</span>
             <span class="detail-value">${node.memory_capacity_gib} GiB</span>
@@ -631,16 +646,18 @@ export class K8sNodesTable extends LitElement {
             <span class="detail-label">Memory Allocatable</span>
             <span class="detail-value">${node.memory_allocatable_gib} GiB</span>
           </div>
-          ${hasMetrics
-            ? html`
-                <div class="detail-item">
-                  <span class="detail-label">Memory Usage</span>
-                  <span class="detail-value"
-                    >${memUsageGib} / ${node.memory_capacity_gib} GiB</span
-                  >
-                </div>
-              `
-            : nothing}
+          ${
+            hasMetrics
+              ? html`
+                  <div class="detail-item">
+                    <span class="detail-label">Memory Usage</span>
+                    <span class="detail-value"
+                      >${memUsageGib} / ${node.memory_capacity_gib} GiB</span
+                    >
+                  </div>
+                `
+              : nothing
+          }
           <div class="detail-item">
             <span class="detail-label">OS Image</span>
             <span class="detail-value">${node.os_image}</span>
@@ -666,19 +683,21 @@ export class K8sNodesTable extends LitElement {
             <span class="detail-value">${node.creation_timestamp}</span>
           </div>
         </div>
-        ${conditions.length > 0
-          ? html`
-              <div class="conditions-row">
-                ${conditions.map(
-                  (c) => html`
-                    <span class="badge badge-condition">
-                      ${CONDITION_LABELS[c] || c}
-                    </span>
-                  `,
-                )}
-              </div>
-            `
-          : nothing}
+        ${
+          conditions.length > 0
+            ? html`
+                <div class="conditions-row">
+                  ${conditions.map(
+                    (c) => html`
+                      <span class="badge badge-condition">
+                        ${CONDITION_LABELS[c] || c}
+                      </span>
+                    `,
+                  )}
+                </div>
+              `
+            : nothing
+        }
       </div>
     `;
   }

--- a/frontend/src/views/k8s-overview.ts
+++ b/frontend/src/views/k8s-overview.ts
@@ -557,19 +557,21 @@ export class K8sOverview extends LitElement {
               </div>
             </span>
           </div>
-          ${totalAlerts > 0
-            ? this._renderAlerts(cluster.alerts)
-            : html`
-                <div class="no-alerts">
-                  <ha-icon icon="mdi:check-circle"></ha-icon>
-                  <div class="no-alerts-text">
-                    <div class="no-alerts-title">No active alerts</div>
-                    <div class="no-alerts-detail">
-                      All nodes, workloads, and pods are operating normally.
+          ${
+            totalAlerts > 0
+              ? this._renderAlerts(cluster.alerts)
+              : html`
+                  <div class="no-alerts">
+                    <ha-icon icon="mdi:check-circle"></ha-icon>
+                    <div class="no-alerts-text">
+                      <div class="no-alerts-title">No active alerts</div>
+                      <div class="no-alerts-detail">
+                        All nodes, workloads, and pods are operating normally.
+                      </div>
                     </div>
                   </div>
-                </div>
-              `}
+                `
+          }
         </div>
 
         ${this._renderNamespaceSection(cluster)}

--- a/frontend/src/views/k8s-pods-table.ts
+++ b/frontend/src/views/k8s-pods-table.ts
@@ -588,9 +588,11 @@ export class K8sPodsTable extends LitElement {
 
     return html`
       <div class="cluster-section">
-        ${this._data!.clusters.length > 1
-          ? html`<div class="cluster-name">${cluster.cluster_name}</div>`
-          : nothing}
+        ${
+          this._data!.clusters.length > 1
+            ? html`<div class="cluster-name">${cluster.cluster_name}</div>`
+            : nothing
+        }
 
         <div class="filters">
           <input
@@ -640,74 +642,94 @@ export class K8sPodsTable extends LitElement {
 
         <div class="pod-count">${filtered.length}/${cluster.pods.length} pods</div>
 
-        ${filtered.length === 0
-          ? html`<div class="empty">No pods match your filters.</div>`
-          : html`
-              <ha-card>
-                <div class="table-wrapper">
-                  <table class="pods-table">
-                    <thead>
-                      <tr>
-                        <th @click=${() => this._handleSort("namespace")}>
-                          Namespace
-                          ${this._sortIcon("namespace")
-                            ? html`<ha-icon
-                                icon=${this._sortIcon("namespace")}
-                              ></ha-icon>`
-                            : nothing}
-                        </th>
-                        <th @click=${() => this._handleSort("name")}>
-                          Name
-                          ${this._sortIcon("name")
-                            ? html`<ha-icon icon=${this._sortIcon("name")}></ha-icon>`
-                            : nothing}
-                        </th>
-                        <th @click=${() => this._handleSort("phase")}>
-                          Phase
-                          ${this._sortIcon("phase")
-                            ? html`<ha-icon icon=${this._sortIcon("phase")}></ha-icon>`
-                            : nothing}
-                        </th>
-                        <th>Ready</th>
-                        <th @click=${() => this._handleSort("restarts")}>
-                          Restarts
-                          ${this._sortIcon("restarts")
-                            ? html`<ha-icon
-                                icon=${this._sortIcon("restarts")}
-                              ></ha-icon>`
-                            : nothing}
-                        </th>
-                        <th
-                          class="col-node"
-                          @click=${() => this._handleSort("node_name")}
-                        >
-                          Node
-                          ${this._sortIcon("node_name")
-                            ? html`<ha-icon
-                                icon=${this._sortIcon("node_name")}
-                              ></ha-icon>`
-                            : nothing}
-                        </th>
-                        <th class="col-ip">IP</th>
-                        <th class="col-owner">Owner</th>
-                        <th @click=${() => this._handleSort("age")}>
-                          Age
-                          ${this._sortIcon("age")
-                            ? html`<ha-icon icon=${this._sortIcon("age")}></ha-icon>`
-                            : nothing}
-                        </th>
-                        <th class="col-actions"></th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      ${filtered.map((pod) =>
-                        this._renderPodRow(cluster.entry_id, pod),
-                      )}
-                    </tbody>
-                  </table>
-                </div>
-              </ha-card>
-            `}
+        ${
+          filtered.length === 0
+            ? html`<div class="empty">No pods match your filters.</div>`
+            : html`
+                <ha-card>
+                  <div class="table-wrapper">
+                    <table class="pods-table">
+                      <thead>
+                        <tr>
+                          <th @click=${() => this._handleSort("namespace")}>
+                            Namespace
+                            ${
+                              this._sortIcon("namespace")
+                                ? html`<ha-icon
+                                    icon=${this._sortIcon("namespace")}
+                                  ></ha-icon>`
+                                : nothing
+                            }
+                          </th>
+                          <th @click=${() => this._handleSort("name")}>
+                            Name
+                            ${
+                              this._sortIcon("name")
+                                ? html`<ha-icon
+                                    icon=${this._sortIcon("name")}
+                                  ></ha-icon>`
+                                : nothing
+                            }
+                          </th>
+                          <th @click=${() => this._handleSort("phase")}>
+                            Phase
+                            ${
+                              this._sortIcon("phase")
+                                ? html`<ha-icon
+                                    icon=${this._sortIcon("phase")}
+                                  ></ha-icon>`
+                                : nothing
+                            }
+                          </th>
+                          <th>Ready</th>
+                          <th @click=${() => this._handleSort("restarts")}>
+                            Restarts
+                            ${
+                              this._sortIcon("restarts")
+                                ? html`<ha-icon
+                                    icon=${this._sortIcon("restarts")}
+                                  ></ha-icon>`
+                                : nothing
+                            }
+                          </th>
+                          <th
+                            class="col-node"
+                            @click=${() => this._handleSort("node_name")}
+                          >
+                            Node
+                            ${
+                              this._sortIcon("node_name")
+                                ? html`<ha-icon
+                                    icon=${this._sortIcon("node_name")}
+                                  ></ha-icon>`
+                                : nothing
+                            }
+                          </th>
+                          <th class="col-ip">IP</th>
+                          <th class="col-owner">Owner</th>
+                          <th @click=${() => this._handleSort("age")}>
+                            Age
+                            ${
+                              this._sortIcon("age")
+                                ? html`<ha-icon
+                                    icon=${this._sortIcon("age")}
+                                  ></ha-icon>`
+                                : nothing
+                            }
+                          </th>
+                          <th class="col-actions"></th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        ${filtered.map((pod) =>
+                          this._renderPodRow(cluster.entry_id, pod),
+                        )}
+                      </tbody>
+                    </table>
+                  </div>
+                </ha-card>
+              `
+        }
       </div>
     `;
   }
@@ -727,9 +749,13 @@ export class K8sPodsTable extends LitElement {
         <td class="col-node">${pod.node_name}</td>
         <td class="col-ip mono">${pod.pod_ip}</td>
         <td class="col-owner">
-          ${pod.owner_kind !== "N/A"
-            ? html`<span class="owner-info">${pod.owner_kind}/${pod.owner_name}</span>`
-            : html`<span class="owner-info">-</span>`}
+          ${
+            pod.owner_kind !== "N/A"
+              ? html`<span class="owner-info"
+                  >${pod.owner_kind}/${pod.owner_name}</span
+                >`
+              : html`<span class="owner-info">-</span>`
+          }
         </td>
         <td>${this._formatAge(pod.creation_timestamp)}</td>
         <td>

--- a/frontend/src/views/k8s-settings.ts
+++ b/frontend/src/views/k8s-settings.ts
@@ -354,26 +354,28 @@ export class K8sSettings extends LitElement {
             >${this._renderBool(entry.monitor_all_namespaces)}</span
           >
         </div>
-        ${!entry.monitor_all_namespaces && entry.namespaces.length > 0
-          ? html`
-              <div class="setting-row">
-                <span class="setting-label">Selected</span>
-                <span class="setting-value">
-                  <div class="namespace-tags">
-                    ${entry.namespaces.map(
-                      (ns) => html`<span class="ns-tag">${ns}</span>`,
-                    )}
-                  </div>
-                </span>
-              </div>
-            `
-          : nothing}
+        ${
+          !entry.monitor_all_namespaces && entry.namespaces.length > 0
+            ? html`
+                <div class="setting-row">
+                  <span class="setting-label">Selected</span>
+                  <span class="setting-value">
+                    <div class="namespace-tags">
+                      ${entry.namespaces.map(
+                        (ns) => html`<span class="ns-tag">${ns}</span>`,
+                      )}
+                    </div>
+                  </span>
+                </div>
+              `
+            : nothing
+        }
         <div class="setting-row">
           <span class="setting-label">Device Grouping</span>
           <span class="setting-value"
-            >${entry.device_grouping_mode === "namespace"
-              ? "By Namespace"
-              : "By Cluster"}</span
+            >${
+              entry.device_grouping_mode === "namespace" ? "By Namespace" : "By Cluster"
+            }</span
           >
         </div>
       </ha-card>

--- a/frontend/src/views/k8s-workloads.ts
+++ b/frontend/src/views/k8s-workloads.ts
@@ -66,12 +66,7 @@ interface WorkloadsResponse {
 }
 
 type WorkloadCategory =
-  | "all"
-  | "deployments"
-  | "statefulsets"
-  | "daemonsets"
-  | "cronjobs"
-  | "jobs";
+  "all" | "deployments" | "statefulsets" | "daemonsets" | "cronjobs" | "jobs";
 type StatusFilter = "all" | "healthy" | "degraded" | "stopped";
 
 @customElement("k8s-workloads")
@@ -556,22 +551,24 @@ export class K8sWorkloads extends LitElement {
     }
 
     return html`
-      ${this._actionError
-        ? html`
-            <div class="action-error">
-              <span>${this._actionError}</span>
-              <button
-                class="dismiss-btn"
-                @click=${() => {
-                  this._actionError = null;
-                }}
-                title="Dismiss"
-              >
-                <ha-icon icon="mdi:close"></ha-icon>
-              </button>
-            </div>
-          `
-        : nothing}
+      ${
+        this._actionError
+          ? html`
+              <div class="action-error">
+                <span>${this._actionError}</span>
+                <button
+                  class="dismiss-btn"
+                  @click=${() => {
+                    this._actionError = null;
+                  }}
+                  title="Dismiss"
+                >
+                  <ha-icon icon="mdi:close"></ha-icon>
+                </button>
+              </div>
+            `
+          : nothing
+      }
       ${this._data.clusters.map((c) => this._renderCluster(c))}
     `;
   }
@@ -581,9 +578,11 @@ export class K8sWorkloads extends LitElement {
 
     return html`
       <div class="cluster-section">
-        ${this._data!.clusters.length > 1
-          ? html`<div class="cluster-name">${cluster.cluster_name}</div>`
-          : nothing}
+        ${
+          this._data!.clusters.length > 1
+            ? html`<div class="cluster-name">${cluster.cluster_name}</div>`
+            : nothing
+        }
 
         <div class="filters">
           <input
@@ -638,18 +637,26 @@ export class K8sWorkloads extends LitElement {
           )}
         </div>
 
-        ${this._shouldShowCategory("deployments")
-          ? this._renderDeployments(cluster.deployments, cluster.entry_id)
-          : nothing}
-        ${this._shouldShowCategory("statefulsets")
-          ? this._renderStatefulSets(cluster.statefulsets, cluster.entry_id)
-          : nothing}
-        ${this._shouldShowCategory("daemonsets")
-          ? this._renderDaemonSets(cluster.daemonsets, cluster.entry_id)
-          : nothing}
-        ${this._shouldShowCategory("cronjobs")
-          ? this._renderCronJobs(cluster.cronjobs, cluster.entry_id)
-          : nothing}
+        ${
+          this._shouldShowCategory("deployments")
+            ? this._renderDeployments(cluster.deployments, cluster.entry_id)
+            : nothing
+        }
+        ${
+          this._shouldShowCategory("statefulsets")
+            ? this._renderStatefulSets(cluster.statefulsets, cluster.entry_id)
+            : nothing
+        }
+        ${
+          this._shouldShowCategory("daemonsets")
+            ? this._renderDaemonSets(cluster.daemonsets, cluster.entry_id)
+            : nothing
+        }
+        ${
+          this._shouldShowCategory("cronjobs")
+            ? this._renderCronJobs(cluster.cronjobs, cluster.entry_id)
+            : nothing
+        }
         ${this._shouldShowCategory("jobs") ? this._renderJobs(cluster.jobs) : nothing}
       </div>
     `;
@@ -745,45 +752,47 @@ export class K8sWorkloads extends LitElement {
             ${this._statusLabel(status)}
           </span>
           <div class="workload-actions">
-            ${d.replicas === 0
-              ? html`
-                  <button
-                    class="action-btn start"
-                    title="Start (scale to 1)"
-                    ?disabled=${busy}
-                    @click=${() =>
-                      this._callService(
-                        "start_workload",
-                        {
-                          workload_name: d.name,
-                          namespace: d.namespace,
-                          entry_id: entryId,
-                        },
-                        actionKey,
-                      )}
-                  >
-                    <ha-icon icon="mdi:play"></ha-icon>
-                  </button>
-                `
-              : html`
-                  <button
-                    class="action-btn stop"
-                    title="Stop (scale to 0)"
-                    ?disabled=${busy}
-                    @click=${() =>
-                      this._callService(
-                        "stop_workload",
-                        {
-                          workload_name: d.name,
-                          namespace: d.namespace,
-                          entry_id: entryId,
-                        },
-                        actionKey,
-                      )}
-                  >
-                    <ha-icon icon="mdi:stop"></ha-icon>
-                  </button>
-                `}
+            ${
+              d.replicas === 0
+                ? html`
+                    <button
+                      class="action-btn start"
+                      title="Start (scale to 1)"
+                      ?disabled=${busy}
+                      @click=${() =>
+                        this._callService(
+                          "start_workload",
+                          {
+                            workload_name: d.name,
+                            namespace: d.namespace,
+                            entry_id: entryId,
+                          },
+                          actionKey,
+                        )}
+                    >
+                      <ha-icon icon="mdi:play"></ha-icon>
+                    </button>
+                  `
+                : html`
+                    <button
+                      class="action-btn stop"
+                      title="Stop (scale to 0)"
+                      ?disabled=${busy}
+                      @click=${() =>
+                        this._callService(
+                          "stop_workload",
+                          {
+                            workload_name: d.name,
+                            namespace: d.namespace,
+                            entry_id: entryId,
+                          },
+                          actionKey,
+                        )}
+                    >
+                      <ha-icon icon="mdi:stop"></ha-icon>
+                    </button>
+                  `
+            }
             <button
               class="action-btn restart"
               title="Rolling restart"
@@ -851,45 +860,47 @@ export class K8sWorkloads extends LitElement {
             ${this._statusLabel(status)}
           </span>
           <div class="workload-actions">
-            ${s.replicas === 0
-              ? html`
-                  <button
-                    class="action-btn start"
-                    title="Start (scale to 1)"
-                    ?disabled=${busy}
-                    @click=${() =>
-                      this._callService(
-                        "start_workload",
-                        {
-                          workload_name: s.name,
-                          namespace: s.namespace,
-                          entry_id: entryId,
-                        },
-                        actionKey,
-                      )}
-                  >
-                    <ha-icon icon="mdi:play"></ha-icon>
-                  </button>
-                `
-              : html`
-                  <button
-                    class="action-btn stop"
-                    title="Stop (scale to 0)"
-                    ?disabled=${busy}
-                    @click=${() =>
-                      this._callService(
-                        "stop_workload",
-                        {
-                          workload_name: s.name,
-                          namespace: s.namespace,
-                          entry_id: entryId,
-                        },
-                        actionKey,
-                      )}
-                  >
-                    <ha-icon icon="mdi:stop"></ha-icon>
-                  </button>
-                `}
+            ${
+              s.replicas === 0
+                ? html`
+                    <button
+                      class="action-btn start"
+                      title="Start (scale to 1)"
+                      ?disabled=${busy}
+                      @click=${() =>
+                        this._callService(
+                          "start_workload",
+                          {
+                            workload_name: s.name,
+                            namespace: s.namespace,
+                            entry_id: entryId,
+                          },
+                          actionKey,
+                        )}
+                    >
+                      <ha-icon icon="mdi:play"></ha-icon>
+                    </button>
+                  `
+                : html`
+                    <button
+                      class="action-btn stop"
+                      title="Stop (scale to 0)"
+                      ?disabled=${busy}
+                      @click=${() =>
+                        this._callService(
+                          "stop_workload",
+                          {
+                            workload_name: s.name,
+                            namespace: s.namespace,
+                            entry_id: entryId,
+                          },
+                          actionKey,
+                        )}
+                    >
+                      <ha-icon icon="mdi:stop"></ha-icon>
+                    </button>
+                  `
+            }
             <button
               class="action-btn restart"
               title="Rolling restart"
@@ -1024,19 +1035,25 @@ export class K8sWorkloads extends LitElement {
             <div class="workload-namespace">${cj.namespace}</div>
           </div>
           <span class="schedule-info">${cj.schedule}</span>
-          ${cj.active_jobs_count > 0
-            ? html`<span class="badge badge-active"
-                >${cj.active_jobs_count} active</span
-              >`
-            : nothing}
-          ${cj.suspend
-            ? html`<span class="badge badge-suspended">Suspended</span>`
-            : html`<span class="badge badge-healthy">Active</span>`}
-          ${cj.last_schedule_time
-            ? html`<span class="last-schedule"
-                >Last: ${this._formatAge(cj.last_schedule_time)}</span
-              >`
-            : nothing}
+          ${
+            cj.active_jobs_count > 0
+              ? html`<span class="badge badge-active"
+                  >${cj.active_jobs_count} active</span
+                >`
+              : nothing
+          }
+          ${
+            cj.suspend
+              ? html`<span class="badge badge-suspended">Suspended</span>`
+              : html`<span class="badge badge-healthy">Active</span>`
+          }
+          ${
+            cj.last_schedule_time
+              ? html`<span class="last-schedule"
+                  >Last: ${this._formatAge(cj.last_schedule_time)}</span
+                >`
+              : nothing
+          }
           <div class="workload-actions">
             <button
               class="action-btn start"
@@ -1107,20 +1124,28 @@ export class K8sWorkloads extends LitElement {
             <div class="workload-namespace">${j.namespace}</div>
           </div>
           <span class="replica-info"> ${j.succeeded}/${j.completions} completed </span>
-          ${j.active > 0
-            ? html`<span class="badge badge-active">${j.active} active</span>`
-            : nothing}
-          ${hasFailed
-            ? html`<span class="badge badge-failed">${j.failed} failed</span>`
-            : nothing}
-          ${isComplete
-            ? html`<span class="badge badge-complete">Complete</span>`
-            : nothing}
-          ${j.start_time
-            ? html`<span class="last-schedule"
-                >Started: ${this._formatAge(j.start_time)}</span
-              >`
-            : nothing}
+          ${
+            j.active > 0
+              ? html`<span class="badge badge-active">${j.active} active</span>`
+              : nothing
+          }
+          ${
+            hasFailed
+              ? html`<span class="badge badge-failed">${j.failed} failed</span>`
+              : nothing
+          }
+          ${
+            isComplete
+              ? html`<span class="badge badge-complete">Complete</span>`
+              : nothing
+          }
+          ${
+            j.start_time
+              ? html`<span class="last-schedule"
+                  >Started: ${this._formatAge(j.start_time)}</span
+                >`
+              : nothing
+          }
         </div>
       </ha-card>
     `;


### PR DESCRIPTION
## Why

PR #280 bumped Prettier to `^3.9.0`, whose formatting differs from the committed frontend source. The `frontend` job's **format:check** step failed — but `frontend` was **not** a required status check, so auto-merge merged #280 anyway and left `main` red.

## What

- Reformatted the affected view files with Prettier 3.9 (`k8s-nodes-table`, `k8s-pods-table`, `k8s-settings`, `k8s-workloads`, `k8s-overview`)
- Regenerated the committed `kubernetes-panel.js` bundle via `vite build`

## Related

Branch protection on `main` was also updated to require all PR checks (incl. `frontend`, CodeQL/Analyze, codecov) so a failing pipeline can no longer auto-merge.