### PR TITLE
ci: skip redundant main re-runs and path-filter docs deploy

### DIFF
--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -13,10 +13,43 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded PR runs; never cancel the post-merge run on main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  frontend:
+  # Skip the post-merge re-run on main when the commit already arrived via a
+  # merged PR (validated there). Direct pushes to main still run.
+  gate:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.head_ref != 'release-please--branches--main'
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+    steps:
+      - id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" != "push" ] || [ "${{ github.ref }}" != "refs/heads/main" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          prs=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" --jq 'length')
+          if [ "$prs" -gt 0 ]; then
+            echo "From a merged PR — already validated; skipping main re-run."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  frontend:
+    needs: gate
+    runs-on: ubuntu-latest
+    if: >-
+      needs.gate.outputs.run == 'true' &&
+      (github.event_name != 'pull_request' || github.head_ref != 'release-please--branches--main')
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/mkdocs.yaml
+++ b/.github/workflows/mkdocs.yaml
@@ -3,6 +3,12 @@ on:
   push:
     branches:
       - main
+    # Only rebuild+redeploy the site when the docs sources or build config
+    # actually change — not on every unrelated push to main.
+    paths:
+      - "docs/**"
+      - "zensical.toml"
+      - ".github/workflows/mkdocs.yaml"
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,14 +14,44 @@ permissions:
   contents: read
   pull-requests: write
 
+# Cancel superseded PR runs; never cancel the post-merge run on main.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   PYTHON_VERSION: "3.14"
 
 jobs:
+  # Skip the post-merge re-run on main when the commit already arrived via a
+  # merged PR (validated there). Direct pushes to main still run.
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+    steps:
+      - id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" != "push" ] || [ "${{ github.ref }}" != "refs/heads/main" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          prs=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" --jq 'length')
+          if [ "$prs" -gt 0 ]; then
+            echo "From a merged PR — already validated; skipping main re-run."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
   lint:
     name: Lint, Type Check & Security
+    needs: gate
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.head_ref != 'release-please--branches--main'
+    if: >-
+      needs.gate.outputs.run == 'true' &&
+      (github.event_name != 'pull_request' || github.head_ref != 'release-please--branches--main')
 
     steps:
       - uses: actions/checkout@v7
@@ -62,8 +92,11 @@ jobs:
 
   test:
     name: Test & Coverage
+    needs: gate
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.head_ref != 'release-please--branches--main'
+    if: >-
+      needs.gate.outputs.run == 'true' &&
+      (github.event_name != 'pull_request' || github.head_ref != 'release-please--branches--main')
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Why

Reduce wasted CI compute and run-list noise. Public repo (no free-minute saving), but several workflows re-ran on every push to `main` after the PR had already validated them.

## What

- **`tests.yaml`** (lint + pytest) and **`frontend.yaml`**: added a skip-main-if-PR-was-green `gate` job — on a push to `main` from a merged PR, skip the post-merge re-run (already validated on the PR). Direct pushes to `main` still run. Existing `release-please--branches--main` exclusions are preserved.
- **`mkdocs.yaml`**: added a `paths:` filter (`docs/**`, `zensical.toml`, the workflow file) so the GitHub Pages site only rebuilds + redeploys when docs sources actually change — not on every unrelated push to `main`. (No skip gate here — it's a deploy.)
- **Concurrency cancellation** for superseded PR runs on `tests.yaml` and `frontend.yaml`.

## Untouched on purpose

`hacs.yaml` / `hassfest.yaml` (already PR-only), `release.yaml`, `claude.yml`, `claude-code-review.yml`.
