### PR TITLE
chore(quality): quality scale quick wins — PARALLEL_UPDATES, 95% coverage gate, 100% config flow coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,8 @@ Cluster device → (optional) Namespace devices → Entity instances. Grouping m
 ### Patterns
 
 - All entities read cached data from the coordinator, never calling the K8s API directly.
+- All four entity platforms (`sensor`, `switch`, `binary_sensor`, `event`) set module-level `PARALLEL_UPDATES = 0` — updates are centralized in the coordinator, so per-entity throttling is unnecessary (HA quality scale `parallel-updates` rule).
+- The pytest coverage gate is `--cov-fail-under=95` in `pyproject.toml`; keep new code tested so overall coverage stays above 95%.
 - `asyncio_mode = "auto"` in pytest — test functions are automatically treated as async. `asyncio_default_fixture_loop_scope = "function"` is set for compatibility with `pytest-homeassistant-custom-component`.
 - Tests use `pytest-homeassistant-custom-component` for real HA test fixtures. Most test files (`test_init.py`, `test_device.py`, `test_config_flow.py`, `test_coordinator.py`, `test_services.py`, `test_binary_sensor.py`, `test_switch.py`, `test_sensors.py`, `test_kubernetes_integration.py`) use the real `hass` fixture and `MockConfigEntry`. Config flow tests register the handler via `HANDLERS` + `DATA_COMPONENTS` fixture (see `register_config_flow` in `test_config_flow.py`). `test_switch_platform.py` has been merged into `test_switch.py`. Only `test_websocket_api.py` still uses `mock_hass` from `conftest.py`. K8s-specific mock fixtures (`mock_client`, `mock_coordinator`, `mock_kubernetes_client`, `mock_kubernetes_api`) remain in `conftest.py`.
 - The kubernetes package is lazy-imported in config_flow via `_ensure_kubernetes_imported()` using thread-safe double-checked locking and checked at setup to handle missing dependency.

--- a/custom_components/kubernetes/binary_sensor.py
+++ b/custom_components/kubernetes/binary_sensor.py
@@ -22,6 +22,9 @@ from .kubernetes_client import KubernetesClient
 
 _LOGGER = logging.getLogger(__name__)
 
+# Data updates are centralized in the coordinator (quality scale: parallel-updates)
+PARALLEL_UPDATES = 0
+
 # Node conditions exposed as binary sensors: condition_key -> display name
 _NODE_CONDITIONS: dict[str, str] = {
     "memory_pressure": "Memory Pressure",

--- a/custom_components/kubernetes/config_flow.py
+++ b/custom_components/kubernetes/config_flow.py
@@ -377,9 +377,8 @@ class KubernetesConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: i
                 namespace_options = [
                     SelectOptionDict(value=ns, label=ns) for ns in fetched_namespaces
                 ]
-                # Default to first namespace if no previous selection
-                if not default_selected and fetched_namespaces:
-                    default_selected = [fetched_namespaces[0]]
+                # Default to first namespace as the pre-selected option
+                default_selected = [fetched_namespaces[0]]
             else:
                 _LOGGER.warning(
                     "No namespaces were fetched from cluster. "

--- a/custom_components/kubernetes/event.py
+++ b/custom_components/kubernetes/event.py
@@ -23,6 +23,9 @@ from .device import get_cluster_device_info
 
 _LOGGER = logging.getLogger(__name__)
 
+# The event entity is push-based via dispatcher (quality scale: parallel-updates)
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/kubernetes/sensor.py
+++ b/custom_components/kubernetes/sensor.py
@@ -24,6 +24,9 @@ from .device import get_cluster_device_info, get_namespace_device_info
 
 _LOGGER = logging.getLogger(__name__)
 
+# Data updates are centralized in the coordinator (quality scale: parallel-updates)
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/kubernetes/switch.py
+++ b/custom_components/kubernetes/switch.py
@@ -31,6 +31,10 @@ from .device import get_cluster_device_info, get_namespace_device_info
 
 _LOGGER = logging.getLogger(__name__)
 
+# Data updates are centralized in the coordinator; switch actions are async
+# K8s API calls that are safe to run concurrently (quality scale: parallel-updates)
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ addopts = [
     "--cov-report=term-missing:skip-covered",
     "--cov-report=html:htmlcov",
     "--cov-report=xml",
-    "--cov-fail-under=80",
+    "--cov-fail-under=95",
 ]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.data_entry_flow import AbortFlow, FlowResultType
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -1531,6 +1531,41 @@ class TestReconfigureFlow:
         assert result["type"] is FlowResultType.FORM
         assert result["errors"]["base"] == "cannot_connect"
 
+    async def test_reconfigure_abort_flow_propagates(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ):
+        """Test AbortFlow is re-raised instead of becoming a cannot_connect error."""
+        with (
+            patch(
+                "custom_components.kubernetes.config_flow._ensure_kubernetes_imported",
+                return_value=True,
+            ),
+            patch(
+                "custom_components.kubernetes.config_flow.KUBERNETES_AVAILABLE",
+                True,
+            ),
+            patch.object(
+                KubernetesConfigFlow,
+                "_test_connection",
+                new_callable=AsyncMock,
+                side_effect=AbortFlow("already_configured"),
+            ),
+        ):
+            result = await self._init_reconfigure(hass, mock_config_entry)
+
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                user_input={
+                    CONF_HOST: "new-host.example.com",
+                    CONF_PORT: 6443,
+                    CONF_API_TOKEN: "new-token",
+                    CONF_MONITOR_ALL_NAMESPACES: True,
+                },
+            )
+
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "already_configured"
+
     async def test_reconfigure_preserves_cluster_name(
         self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
     ):
@@ -2948,6 +2983,50 @@ def test_ensure_kubernetes_imported_cached_false():
         assert result is False
     finally:
         cf_module.KUBERNETES_AVAILABLE = original
+
+
+def test_ensure_kubernetes_imported_set_while_waiting_for_lock():
+    """Test the re-check inside the lock when another thread won the race."""
+    import custom_components.kubernetes.config_flow as cf_module
+
+    original = cf_module.KUBERNETES_AVAILABLE
+    cf_module.KUBERNETES_AVAILABLE = None
+
+    def _other_thread_wins_race():
+        cf_module.KUBERNETES_AVAILABLE = True
+
+    # Stand-in lock that simulates another thread completing the import while
+    # this caller was blocked on acquiring it.
+    lock = MagicMock()
+    lock.__enter__.side_effect = _other_thread_wins_race
+
+    try:
+        with patch.object(cf_module, "_import_lock", lock):
+            assert cf_module._ensure_kubernetes_imported() is True
+    finally:
+        cf_module.KUBERNETES_AVAILABLE = original
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage: in-cluster port parsing
+# ---------------------------------------------------------------------------
+
+
+def test_read_in_cluster_config_non_numeric_port_falls_back_to_443(monkeypatch):
+    """Test a non-numeric KUBERNETES_SERVICE_PORT_HTTPS falls back to 443."""
+    import custom_components.kubernetes.config_flow as cf_module
+
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+    monkeypatch.setenv("KUBERNETES_SERVICE_PORT_HTTPS", "not-a-number")
+
+    with (
+        patch.object(cf_module, "_service_account_token_exists", return_value=True),
+        patch.object(cf_module, "_read_service_account_token", return_value="t"),
+        patch.object(cf_module, "_service_account_ca_exists", return_value=False),
+    ):
+        config = cf_module._read_in_cluster_config_sync()
+
+    assert config == {"host": "10.0.0.1", "port": 443, "api_token": "t"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
First PR toward voluntarily meeting the HA Quality Scale Bronze/Silver requirements.

## Changes

- **parallel-updates (Silver)**: all four entity platforms (`sensor`, `switch`, `binary_sensor`, `event`) now set module-level `PARALLEL_UPDATES = 0` — data updates are centralized in the coordinator, and switch actions are concurrent-safe async K8s API calls.
- **test-coverage (Silver)**: coverage gate raised from `--cov-fail-under=80` to `95`, matching the actual current coverage (96%) so it is now enforced.
- **config-flow-test-coverage (Bronze)**: three new tests close the last uncovered lines/branches in `config_flow.py`:
  - in-cluster detection falls back to port 443 on a non-numeric `KUBERNETES_SERVICE_PORT_HTTPS`
  - double-checked-locking re-check in `_ensure_kubernetes_imported()` when another thread wins the import race
  - `AbortFlow` propagates out of the reconfigure step instead of being swallowed as `cannot_connect`
- Removed a statically dead guard in `async_step_namespaces` (`default_selected` is always empty and `fetched_namespaces` always truthy at that point) — no behavior change.
- CLAUDE.md updated with the new conventions.

## Remaining quality-scale gaps (follow-up PRs)

1. Move service registration to `async_setup` + raise `HomeAssistantError`/`ServiceValidationError` from service handlers (Bronze action-setup, Silver action-exceptions)
2. `hass.data[DOMAIN]` → `entry.runtime_data` (Bronze runtime-data)
3. Reauthentication flow (Silver reauthentication-flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)